### PR TITLE
Remove parentView of hookView before adding it to another parentView

### DIFF
--- a/library/src/main/java/com/architjn/sharepanel/SharePanel.java
+++ b/library/src/main/java/com/architjn/sharepanel/SharePanel.java
@@ -45,6 +45,8 @@ public class SharePanel extends CardView {
         super.onLayout(changed, left, top, right, bottom);
         if (getParent() instanceof CoordinatorLayout) {
             parentView = ((CoordinatorLayout) getParent());
+            if (hookView.getParent() != null)
+                ((ViewGroup) hookView.getParent()).removeView(hookView);
             parentView.addView(hookView);
             if (attrs != null) {
                 CoordinatorLayout.LayoutParams lp = (CoordinatorLayout.LayoutParams) hookView.getLayoutParams();


### PR DESCRIPTION
If hookView already has a parentView then it may through "The specified child already has a parent" exception